### PR TITLE
Patch class

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,25 +11,17 @@ This is a very preliminary utility gem to apply and revert patches to strings (t
 of the main intended use cases for this plugin is source-code modification, e.g.
 when automatically integrating an SDK.
 
-The current API is low-level, having evolved out of a Fastlane plugin helper. A better data model
-will probably arise in later releases.
-
 Please provide any feedback via issues in this repo.
 
 ```Ruby
 require "pattern_patch"
 
 # Add a meta-data key to the end of the application element of an Android manifest
-modified = File.open("AndroidManifest.xml") do |file|
-  PatternPatch::Utilities.apply_patch file.read,
-                                      %r{^\s*</application>},
-                                      "        <meta-data android:name=\"foo\" android:value=\"bar\" />\n",
-                                      false,
-                                      :prepend,
-                                      0
-end
-
-File.open("AndroidManifest.xml", "w") { |f| f.write modified }
+PatternPatch::Patch.new(
+  regexp: %r{^\s*</application>},
+  text: "        <meta-data android:name=\"foo\" android:value=\"bar\" />\n",
+  mode: :prepend
+).apply "AndroidManifest.xml"
 ```
 
 Capture groups may be used within the text argument in any mode. Note that
@@ -37,19 +29,12 @@ this works best without interpolation (single quotes or %q). If you use double
 quotes, the backslash must be escaped, e.g. `text: "\\1\"MyOtherpod\""`.
 
 ```Ruby
-require "pattern_patch"
-
 # Change the name of a pod in a podspec
-modified = File.open("AndroidManifest.xml") do |file|
-  PatternPatch::Utilities.apply_patch file.read,
-                                      /(s\.name\s*=\s*)"MyPod"/,
-                                      '\1"MyOtherPod"',
-                                      false,
-                                      :replace,
-                                      0
-end
-
-File.open("AndroidManifest.xml", "w") { |f| f.write modified }
+PatternPatch::Patch.new(
+  regexp: /(s\.name\s*=\s*)"MyPod"/,
+  text: '\1"MyOtherPod"',
+  mode: :replace
+).apply "MyPod.podspec"
 ```
 
 Patches in `:append` mode using capture groups in the text argument may be
@@ -61,16 +46,19 @@ Revert patches by passing the optional `:revert` parameter:
 
 ```Ruby
 # Revert the patch that added the metadata key to the end of the Android manifest, resulting in the original.
-modified = File.open("AndroidManifest.xml") do |file|
-  PatternPatch::Utilities.revert_patch file.read,
-                                      %r{^\s*</application>},
-                                      "        <meta-data android:name=\"foo\" android:value=\"bar\" />\n",
-                                      false,
-                                      :prepend,
-                                      0
-end
-
-File.open("AndroidManifest.xml", "w") { |f| f.write modified }
+PatternPatch::Patch.new(
+  regexp: %r{^\s*</application>},
+  text: "        <meta-data android:name=\"foo\" android:value=\"bar\" />\n",
+  mode: :prepend
+).apply "AndroidManifest.xml"
 ```
 
 Patches using the `:replace` mode cannot be reverted.
+
+#### Define patches in YAML files
+
+Load a patch defined in YAML and apply it.
+
+```Ruby
+PatternPatch::Patch.from_yaml("patch.yaml").apply "file.txt"
+```

--- a/lib/pattern_patch.rb
+++ b/lib/pattern_patch.rb
@@ -1,3 +1,4 @@
 require "pattern_patch/core_ext"
+require "pattern_patch/patch"
 require "pattern_patch/utilities"
 require "pattern_patch/version"

--- a/lib/pattern_patch/patch.rb
+++ b/lib/pattern_patch/patch.rb
@@ -1,0 +1,56 @@
+require "yaml"
+
+module PatternPatch
+  class Patch
+    attr_accessor :regexp
+    attr_accessor :text
+    attr_accessor :mode
+    attr_accessor :global
+
+    class << self
+      def from_yaml(path)
+        hash = YAML.load_file path
+        new hash
+      end
+    end
+
+    def initialize(options = {})
+      @regexp = options[:regexp]
+      @text = options[:text]
+      @mode = options[:mode] || :append
+      @global = options[:global]
+    end
+
+    def apply(files, options = {})
+      offset = options.offset || 0
+
+      files.each do |path|
+        modified = Utilities.apply_patch File.read(path),
+                                         regexp,
+                                         text,
+                                         global,
+                                         mode,
+                                         offset
+        File.write path, modified
+      end
+    end
+
+    def revert(files, options = {})
+      offset = options.offset || 0
+
+      files.each do |path|
+        modified = Utilities.revert_patch File.read(path),
+                                          regexp,
+                                          text,
+                                          global,
+                                          mode,
+                                          offset
+        File.write path, modified
+      end
+    end
+
+    def inspect
+      "#<PatternPatch::Patch regexp=#{regexp.inspect} text=#{text.inspect} mode=#{mode.inspect} global=#{global.inspect}>"
+    end
+  end
+end

--- a/lib/pattern_patch/patch.rb
+++ b/lib/pattern_patch/patch.rb
@@ -10,6 +10,17 @@ module PatternPatch
     class << self
       def from_yaml(path)
         hash = YAML.load_file path
+
+        # Adjust string fields from YAML
+
+        if hash[:regexp].kind_of? String
+          hash[:regexp] = /#{hash[:regexp]}/
+        end
+
+        if hash[:mode].kind_of? String
+          hash[:mode] = hash[:mode].to_sym
+        end
+
         new hash
       end
     end
@@ -22,7 +33,7 @@ module PatternPatch
     end
 
     def apply(files, options = {})
-      offset = options.offset || 0
+      offset = options[:offset] || 0
 
       files.each do |path|
         modified = Utilities.apply_patch File.read(path),
@@ -36,7 +47,7 @@ module PatternPatch
     end
 
     def revert(files, options = {})
-      offset = options.offset || 0
+      offset = options[:offset] || 0
 
       files.each do |path|
         modified = Utilities.revert_patch File.read(path),

--- a/lib/pattern_patch/patch.rb
+++ b/lib/pattern_patch/patch.rb
@@ -18,7 +18,7 @@ module PatternPatch
       @regexp = options[:regexp]
       @text = options[:text]
       @mode = options[:mode] || :append
-      @global = options[:global]
+      @global = options[:global].nil? ? false : options[:global]
     end
 
     def apply(files, options = {})

--- a/lib/pattern_patch/patch.rb
+++ b/lib/pattern_patch/patch.rb
@@ -1,3 +1,4 @@
+require "active_support/core_ext/hash"
 require "yaml"
 
 module PatternPatch
@@ -9,7 +10,7 @@ module PatternPatch
 
     class << self
       def from_yaml(path)
-        hash = YAML.load_file path
+        hash = YAML.load_file(path).symbolize_keys
 
         # Adjust string fields from YAML
 
@@ -34,6 +35,7 @@ module PatternPatch
 
     def apply(files, options = {})
       offset = options[:offset] || 0
+      files = [files] if files.kind_of? String
 
       files.each do |path|
         modified = Utilities.apply_patch File.read(path),
@@ -48,6 +50,7 @@ module PatternPatch
 
     def revert(files, options = {})
       offset = options[:offset] || 0
+      files = [files] if files.kind_of? String
 
       files.each do |path|
         modified = Utilities.revert_patch File.read(path),

--- a/lib/pattern_patch/version.rb
+++ b/lib/pattern_patch/version.rb
@@ -1,3 +1,3 @@
 module PatternPatch
-  VERSION = "0.1.2"
+  VERSION = "0.2.0"
 end

--- a/pattern_patch.gemspec
+++ b/pattern_patch.gemspec
@@ -15,6 +15,8 @@ Gem::Specification.new do |spec|
   spec.homepage    = 'http://github.com/jdee/pattern_patch'
   spec.license     = 'MIT'
 
+  spec.add_dependency 'activesupport'
+
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rake'

--- a/spec/patch_spec.rb
+++ b/spec/patch_spec.rb
@@ -1,11 +1,11 @@
 describe PatternPatch::Patch do
   describe 'initialization' do
     it 'initializes parameters from options' do
-      patch = PatternPatch::Patch.new regexp: //, text: '', mode: :append, global: false
+      patch = PatternPatch::Patch.new regexp: //, text: '', mode: :prepend, global: true
       expect(patch.regexp).to eq(//)
       expect(patch.text).to eq ''
-      expect(patch.mode).to eq :append
-      expect(patch.global).to be false
+      expect(patch.mode).to eq :prepend
+      expect(patch.global).to be true
     end
 
     it 'initializes to default values when no options passed' do
@@ -13,7 +13,7 @@ describe PatternPatch::Patch do
       expect(patch.regexp).to be_nil
       expect(patch.text).to be_nil
       expect(patch.mode).to eq :append
-      expect(patch.global).to be_nil
+      expect(patch.global).to be false
     end
   end
 

--- a/spec/patch_spec.rb
+++ b/spec/patch_spec.rb
@@ -1,0 +1,34 @@
+describe PatternPatch::Patch do
+  describe 'initialization' do
+    it 'initializes parameters from options' do
+      patch = PatternPatch::Patch.new regexp: //, text: '', mode: :append, global: false
+      expect(patch.regexp).to eq(//)
+      expect(patch.text).to eq ''
+      expect(patch.mode).to eq :append
+      expect(patch.global).to be false
+    end
+
+    it 'initializes to default values when no options passed' do
+      patch = PatternPatch::Patch.new
+      expect(patch.regexp).to be_nil
+      expect(patch.text).to be_nil
+      expect(patch.mode).to eq :append
+      expect(patch.global).to be_nil
+    end
+  end
+
+  describe '#inspect' do
+    it 'includes the value of each field' do
+      text = PatternPatch::Patch.new.inspect
+      expect(text).to match(/regexp=/)
+      expect(text).to match(/text=/)
+      expect(text).to match(/mode=/)
+      expect(text).to match(/global=/)
+    end
+  end
+
+  describe '#apply' do
+    it 'passes field values to the Utilities#apply_patch method' do
+    end
+  end
+end

--- a/spec/patch_spec.rb
+++ b/spec/patch_spec.rb
@@ -42,7 +42,7 @@ describe PatternPatch::Patch do
 
       expect(File).to receive(:write).with('file.txt', 'xy')
 
-      patch.apply ['file.txt']
+      patch.apply 'file.txt'
     end
 
     it 'passes the offset option if present' do
@@ -60,7 +60,7 @@ describe PatternPatch::Patch do
 
       expect(File).to receive(:write).with('file.txt', 'x')
 
-      patch.apply ['file.txt'], offset: 1
+      patch.apply 'file.txt', offset: 1
     end
   end
 
@@ -79,7 +79,7 @@ describe PatternPatch::Patch do
 
       expect(File).to receive(:write).with('file.txt', 'x')
 
-      patch.revert ['file.txt']
+      patch.revert 'file.txt'
     end
 
     it 'passes the offset option if present' do
@@ -97,7 +97,7 @@ describe PatternPatch::Patch do
 
       expect(File).to receive(:write).with('file.txt', 'x')
 
-      patch.revert ['file.txt'], offset: 1
+      patch.revert 'file.txt', offset: 1
     end
   end
 


### PR DESCRIPTION
This introduces a better API for this gem, with support for passing file paths to be patched and loading patches from YAML.

```Ruby
require 'pattern_patch'
PatternPatch::Patch.new(
  regexp: /x/,
  text: 'y',
  mode: :prepend
).apply 'file.txt'

PatternPatch::Patch.load_yaml('patch.yml').apply 'file.txt'
```