### PR TITLE
Add ERB support

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,19 @@ PatternPatch::Patch.from_yaml("/path/to/patches/patch.yaml")
 ```
 
 This will load the contents of `/path/to/patches/text_to_insert_at_end.txt`.
+
+#### ERB in text and text_file
+
+You can use ERB in the `text` value or the contents of a `text_file` if you pass
+a `:binding` option to `#apply`:
+
+```Ruby
+replacement_text = "y"
+PatternPatch::Patch.new(
+  regexp: /x/,
+  text: '<%= replacement_text %>',
+  mode: :replace
+).apply file_path, binding: binding
+```
+
+If the `:binding` parameter is not passed, ERB is not invoked.

--- a/lib/pattern_patch/patch.rb
+++ b/lib/pattern_patch/patch.rb
@@ -1,4 +1,5 @@
 require "active_support/core_ext/hash"
+require "erb"
 require "yaml"
 
 module PatternPatch
@@ -56,10 +57,15 @@ module PatternPatch
       offset = options[:offset] || 0
       files = [files] if files.kind_of? String
 
+      patch_text = text
+      if options[:binding]
+        patch_text = ERB.new(text, nil, nil, "@template").result(options[:binding])
+      end
+
       files.each do |path|
         modified = Utilities.apply_patch File.read(path),
                                          regexp,
-                                         text,
+                                         patch_text,
                                          global,
                                          mode,
                                          offset
@@ -71,10 +77,15 @@ module PatternPatch
       offset = options[:offset] || 0
       files = [files] if files.kind_of? String
 
+      patch_text = text
+      if options[:binding]
+        patch_text = ERB.new(text, nil, nil, "@template").result(options[:binding])
+      end
+
       files.each do |path|
         modified = Utilities.revert_patch File.read(path),
                                           regexp,
-                                          text,
+                                          patch_text,
                                           global,
                                           mode,
                                           offset

--- a/lib/pattern_patch/patch.rb
+++ b/lib/pattern_patch/patch.rb
@@ -57,9 +57,10 @@ module PatternPatch
       offset = options[:offset] || 0
       files = [files] if files.kind_of? String
 
-      patch_text = text
       if options[:binding]
-        patch_text = ERB.new(text, nil, nil, "@template").result(options[:binding])
+        patch_text = ERB.new(text).result(options[:binding])
+      else
+        patch_text = text
       end
 
       files.each do |path|
@@ -77,9 +78,10 @@ module PatternPatch
       offset = options[:offset] || 0
       files = [files] if files.kind_of? String
 
-      patch_text = text
       if options[:binding]
-        patch_text = ERB.new(text, nil, nil, "@template").result(options[:binding])
+        patch_text = ERB.new(text).result(options[:binding])
+      else
+        patch_text = text
       end
 
       files.each do |path|

--- a/lib/pattern_patch/version.rb
+++ b/lib/pattern_patch/version.rb
@@ -1,3 +1,3 @@
 module PatternPatch
-  VERSION = "0.3.1"
+  VERSION = "0.4.0"
 end

--- a/spec/patch_spec.rb
+++ b/spec/patch_spec.rb
@@ -37,7 +37,8 @@ describe PatternPatch::Patch do
         patch.regexp,
         patch.text,
         patch.global,
-        patch.mode, 0
+        patch.mode,
+        0
       ) { 'xy' }
 
       expect(File).to receive(:write).with('file.txt', 'xy')
@@ -61,6 +62,25 @@ describe PatternPatch::Patch do
       expect(File).to receive(:write).with('file.txt', 'x')
 
       patch.apply 'file.txt', offset: 1
+    end
+
+    it 'uses ERB if a :binding option is present' do
+      replacement_text = "y"
+      patch = PatternPatch::Patch.new regexp: /x/, text: '<%= replacement_text %>'
+      expect(File).to receive(:read).with('file.txt') { 'x' }
+
+      expect(PatternPatch::Utilities).to receive(:apply_patch).with(
+        'x',
+        patch.regexp,
+        replacement_text,
+        patch.global,
+        patch.mode,
+        0
+      ) { 'xy' }
+
+      expect(File).to receive(:write).with('file.txt', 'xy')
+
+      patch.apply 'file.txt', binding: binding
     end
   end
 
@@ -98,6 +118,24 @@ describe PatternPatch::Patch do
       expect(File).to receive(:write).with('file.txt', 'x')
 
       patch.revert 'file.txt', offset: 1
+    end
+
+    it 'uses ERB if a :binding option is present' do
+      replacement_text = "y"
+      patch = PatternPatch::Patch.new regexp: /x/, text: '<%= replacement_text %>'
+      expect(File).to receive(:read).with('file.txt') { 'xy' }
+
+      expect(PatternPatch::Utilities).to receive(:revert_patch).with(
+        'xy',
+        patch.regexp,
+        replacement_text,
+        patch.global,
+        patch.mode, 0
+      ) { 'x' }
+
+      expect(File).to receive(:write).with('file.txt', 'x')
+
+      patch.revert 'file.txt', binding: binding
     end
   end
 


### PR DESCRIPTION
ERB can now be used in the `text` field or in the contents of a `text_file`.