### PR TITLE
YAML regular expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,3 +105,18 @@ PatternPatch::Patch.new(
 ```
 
 If the `:binding` parameter is not passed, ERB is not invoked.
+
+#### Regular expressions with modifiers in YAML
+
+The `regexp` field in a YAML file may be specified with or without slashes
+or a modifier:
+
+```YAML
+regexp: '^X' # Results in /^X/
+```
+
+```YAML
+regexp: '/^X/i' # Results in /^X/i
+```
+
+Currently only the slash literal notation is supported in YAML.

--- a/lib/pattern_patch/patch.rb
+++ b/lib/pattern_patch/patch.rb
@@ -17,7 +17,23 @@ module PatternPatch
         # Adjust string fields from YAML
 
         if hash[:regexp].kind_of? String
-          hash[:regexp] = /#{hash[:regexp]}/
+          regexp_string = hash[:regexp]
+          if (matches = %r{^/(.+)/([imx]*)$}.match regexp_string)
+            flags = 0
+            if matches[2] =~ /i/
+              flags |= Regexp::IGNORECASE
+            end
+            if matches[2] =~ /x/
+              flags |= Regexp::EXTENDED
+            end
+            if matches[2] =~ /m/
+              flags |= Regexp::MULTILINE
+            end
+            hash[:regexp] = Regexp.new matches[1], flags
+            puts "Regexp from YAML: #{hash[:regexp].inspect}"
+          else
+            hash[:regexp] = /#{regexp_string}/
+          end
         end
 
         if hash[:mode].kind_of? String

--- a/lib/pattern_patch/version.rb
+++ b/lib/pattern_patch/version.rb
@@ -1,3 +1,3 @@
 module PatternPatch
-  VERSION = "0.4.1"
+  VERSION = "0.5.0"
 end


### PR DESCRIPTION
Regular expressions with modifiers may be specified using the slash notation in YAML files, e.g.:

```YAML
regexp: '/^x/i'
```