### PR TITLE
Locals

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,12 +107,21 @@ PatternPatch::Patch.new(
 Optionally pass a `:binding` option to `#apply` to use a specific Binding:
 
 ```Ruby
-replacement_text = "y"
+replacement_text = 'y'
 PatternPatch::Patch.new(
   regexp: /x/,
   text: '<%= replacement_text %>',
   mode: :replace
 ).apply file_path, binding: binding
+```
+
+or a Hash of locals for the template:
+```Ruby
+PatternPatch::Patch.new(
+  regexp: /x/,
+  text: '<%= replacement_text %>',
+  mode: :replace
+).apply file_path, replacement_text: 'y'
 ```
 
 This is particularly useful with a `text_file` argument.

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ PatternPatch::Patch.new(
   regexp: /x/,
   text: '<%= replacement_text %>',
   mode: :replace
-).apply file_path, replacement_text: 'y'
+).apply file_path, locals: { replacement_text: 'y' }
 ```
 
 This is particularly useful with a `text_file` argument.

--- a/lib/pattern_patch/patch.rb
+++ b/lib/pattern_patch/patch.rb
@@ -116,7 +116,7 @@ module PatternPatch
 
     # Applies the patch to one or more files. ERB is processed in the text
     # field, whether it comes from a text_file or not. Pass a Binding to
-    # ERB using the :binding option. Pass the :offset option to specify a
+    # ERB using the :binding option or a Hash of locals. Pass the :offset option to specify a
     # starting offset, in characters, from the beginning of the file.
     #
     # @param files [Array, String] One or more file paths to which to apply the patch.
@@ -133,7 +133,19 @@ module PatternPatch
       safe_level = options[:safe_level] || PatternPatch.safe_level
       trim_mode = options[:trim_mode] || PatternPatch.trim_mode
 
-      patch_text = ERB.new(text, safe_level, trim_mode).result options[:binding]
+      locals = options.clone
+      binding_option = locals.delete :binding
+      locals.delete :offset
+      locals.delete :safe_level
+      locals.delete :trim_mode
+
+      raise ArgumentError, ':binding is incompatible with locals' unless binding_option.nil? || locals.empty?
+
+      if locals.empty?
+        patch_text = ERB.new(text, safe_level, trim_mode).result options[:binding]
+      else
+        patch_text = ERB.new(text, safe_level, trim_mode).result_with_hash locals
+      end
 
       files.each do |path|
         modified = Utilities.apply_patch File.read(path),
@@ -148,7 +160,7 @@ module PatternPatch
 
     # Reverse the effect of a patch on one or more files. ERB is processed in the text
     # field, whether it comes from a text_file or not. Pass a Binding to
-    # ERB using the :binding option. Pass the :offset option to specify a
+    # ERB using the :binding option or a Hash of locals. Pass the :offset option to specify a
     # starting offset, in characters, from the beginning of the file.
     #
     # @param files [Array, String] One or more file paths to which to apply the patch.
@@ -165,7 +177,19 @@ module PatternPatch
       safe_level = options[:safe_level] || PatternPatch.safe_level
       trim_mode = options[:trim_mode] || PatternPatch.trim_mode
 
-      patch_text = ERB.new(text, safe_level, trim_mode).result options[:binding]
+      locals = options.clone
+      binding_option = locals.delete :binding
+      locals.delete :offset
+      locals.delete :safe_level
+      locals.delete :trim_mode
+
+      raise ArgumentError, ':binding is incompatible with locals' unless binding_option.nil? || locals.empty?
+
+      if locals.empty?
+        patch_text = ERB.new(text, safe_level, trim_mode).result options[:binding]
+      else
+        patch_text = ERB.new(text, safe_level, trim_mode).result_with_hash locals
+      end
 
       files.each do |path|
         modified = Utilities.revert_patch File.read(path),

--- a/lib/pattern_patch/patch.rb
+++ b/lib/pattern_patch/patch.rb
@@ -144,6 +144,7 @@ module PatternPatch
       if locals.empty?
         patch_text = ERB.new(text, safe_level, trim_mode).result options[:binding]
       else
+        raise ArgumentError, 'Locals require Ruby >= 2.5.' unless ERB.method_defined?(:result_with_hash)
         patch_text = ERB.new(text, safe_level, trim_mode).result_with_hash locals
       end
 
@@ -188,6 +189,7 @@ module PatternPatch
       if locals.empty?
         patch_text = ERB.new(text, safe_level, trim_mode).result options[:binding]
       else
+        raise ArgumentError, 'Locals require Ruby >= 2.5.' unless ERB.method_defined?(:result_with_hash)
         patch_text = ERB.new(text, safe_level, trim_mode).result_with_hash locals
       end
 

--- a/lib/pattern_patch/patch.rb
+++ b/lib/pattern_patch/patch.rb
@@ -1,6 +1,7 @@
 require 'erb'
 require 'yaml'
 require_relative 'core_ext/hash'
+require_relative 'renderer'
 
 module PatternPatch
   # The PatternPatch::Patch class defines a patch as an operation that
@@ -141,11 +142,11 @@ module PatternPatch
 
       raise ArgumentError, ':binding is incompatible with locals' unless binding_option.nil? || locals.empty?
 
+      renderer = Renderer.new ERB.new(text, safe_level, trim_mode)
       if locals.empty?
-        patch_text = ERB.new(text, safe_level, trim_mode).result options[:binding]
+        patch_text = renderer.render binding_option
       else
-        raise ArgumentError, 'Locals require Ruby >= 2.5.' unless ERB.method_defined?(:result_with_hash)
-        patch_text = ERB.new(text, safe_level, trim_mode).result_with_hash locals
+        patch_text = renderer.render locals
       end
 
       files.each do |path|
@@ -186,11 +187,11 @@ module PatternPatch
 
       raise ArgumentError, ':binding is incompatible with locals' unless binding_option.nil? || locals.empty?
 
+      renderer = Renderer.new ERB.new(text, safe_level, trim_mode)
       if locals.empty?
-        patch_text = ERB.new(text, safe_level, trim_mode).result options[:binding]
+        patch_text = renderer.render binding_option
       else
-        raise ArgumentError, 'Locals require Ruby >= 2.5.' unless ERB.method_defined?(:result_with_hash)
-        patch_text = ERB.new(text, safe_level, trim_mode).result_with_hash locals
+        patch_text = renderer.render locals
       end
 
       files.each do |path|

--- a/lib/pattern_patch/patch.rb
+++ b/lib/pattern_patch/patch.rb
@@ -126,6 +126,7 @@ module PatternPatch
     # @option options [Integer] :offset (0) Offset in characters
     # @option options [Object, nil] :safe_level (PatternPatch.safe_level) A valid value for $SAFE for use with ERb
     # @option options [String] :trim_mode (PatternPatch.trim_mode) A valid ERb trim mode
+    # @option options [Hash] :locals A Hash of local variables for rendering the template
     # @raise [ArgumentError] In case of invalid mode (other than :append, :prepend, :replace)
     def apply(files, options = {})
       offset = options[:offset] || 0
@@ -134,17 +135,13 @@ module PatternPatch
       safe_level = options[:safe_level] || PatternPatch.safe_level
       trim_mode = options[:trim_mode] || PatternPatch.trim_mode
 
-      locals = options.clone
-      binding_option = locals.delete :binding
-      locals.delete :offset
-      locals.delete :safe_level
-      locals.delete :trim_mode
+      locals = options[:locals]
 
-      raise ArgumentError, ':binding is incompatible with locals' unless binding_option.nil? || locals.empty?
+      raise ArgumentError, ':binding is incompatible with :locals' if options[:binding] && locals
 
       renderer = Renderer.new text, safe_level, trim_mode
-      if locals.empty?
-        patch_text = renderer.render binding_option
+      if locals.nil?
+        patch_text = renderer.render options[:binding]
       else
         patch_text = renderer.render locals
       end
@@ -171,6 +168,7 @@ module PatternPatch
     # @option options [Integer] :offset (0) Offset in characters
     # @option options [Object, nil] :safe_level (PatternPatch.safe_level) A valid value for $SAFE for use with ERb
     # @option options [String] :trim_mode (PatternPatch.trim_mode) A valid ERb trim mode
+    # @option options [Hash] :locals A Hash of local variables for rendering the template
     # @raise [ArgumentError] In case of invalid mode (other than :append or :prepend)
     def revert(files, options = {})
       offset = options[:offset] || 0
@@ -179,17 +177,13 @@ module PatternPatch
       safe_level = options[:safe_level] || PatternPatch.safe_level
       trim_mode = options[:trim_mode] || PatternPatch.trim_mode
 
-      locals = options.clone
-      binding_option = locals.delete :binding
-      locals.delete :offset
-      locals.delete :safe_level
-      locals.delete :trim_mode
+      locals = options[:locals]
 
-      raise ArgumentError, ':binding is incompatible with locals' unless binding_option.nil? || locals.empty?
+      raise ArgumentError, ':binding is incompatible with :locals' if options[:binding] && locals
 
       renderer = Renderer.new text, safe_level, trim_mode
-      if locals.empty?
-        patch_text = renderer.render binding_option
+      if locals.nil?
+        patch_text = renderer.render options[:binding]
       else
         patch_text = renderer.render locals
       end

--- a/lib/pattern_patch/patch.rb
+++ b/lib/pattern_patch/patch.rb
@@ -142,7 +142,7 @@ module PatternPatch
 
       raise ArgumentError, ':binding is incompatible with locals' unless binding_option.nil? || locals.empty?
 
-      renderer = Renderer.new ERB.new(text, safe_level, trim_mode)
+      renderer = Renderer.new text, safe_level, trim_mode
       if locals.empty?
         patch_text = renderer.render binding_option
       else
@@ -187,7 +187,7 @@ module PatternPatch
 
       raise ArgumentError, ':binding is incompatible with locals' unless binding_option.nil? || locals.empty?
 
-      renderer = Renderer.new ERB.new(text, safe_level, trim_mode)
+      renderer = Renderer.new text, safe_level, trim_mode
       if locals.empty?
         patch_text = renderer.render binding_option
       else

--- a/lib/pattern_patch/renderer.rb
+++ b/lib/pattern_patch/renderer.rb
@@ -1,0 +1,30 @@
+module PatternPatch
+  class Renderer
+    attr_reader :template
+
+    def initialize(template)
+      @template = template
+      @locals = {}
+    end
+
+    def render(locals = {})
+      if !locals.kind_of?(Hash)
+        template.result locals
+      elsif template.respond_to? :result_with_hash
+        # ERB#result_with_hash requires Ruby 2.5.
+        template.result_with_hash locals
+      else
+        @locals = locals
+        template.result binding
+      end
+    end
+
+    def method_missing(method_sym, *args, &block)
+      local_value = @locals[method_sym]
+      # This approach makes it hard to pass nil for a local
+      return super if local_value.nil?
+
+      local_value
+    end
+  end
+end

--- a/lib/pattern_patch/renderer.rb
+++ b/lib/pattern_patch/renderer.rb
@@ -1,7 +1,7 @@
+require_relative 'core_ext/hash'
+
 module PatternPatch
   class Renderer
-    attr_reader :template
-
     def initialize(text, safe_level = nil, trim_mode = nil)
       @template = ERB.new text, safe_level, trim_mode
       @locals = {}
@@ -16,13 +16,13 @@ module PatternPatch
     def render(locals_or_binding = {})
       if !locals_or_binding.kind_of?(Hash)
         # Pass a Binding this way.
-        template.result locals_or_binding
+        @template.result locals_or_binding
       elsif template.respond_to? :result_with_hash
         # ERB#result_with_hash requires Ruby 2.5.
-        template.result_with_hash locals_or_binding
+        @template.result_with_hash locals_or_binding
       else
-        @locals = locals_or_binding
-        template.result binding
+        @locals = locals_or_binding.symbolize_keys
+        @template.result binding
       end
     end
 

--- a/lib/pattern_patch/renderer.rb
+++ b/lib/pattern_patch/renderer.rb
@@ -1,6 +1,10 @@
 require_relative 'core_ext/hash'
 
 module PatternPatch
+  # Provides a fairly clean binding for resolving locals in Ruby < 2.5.
+  # All locals become method calls in the binding passed to ERB. A separate
+  # class (instead of a Module, e.g.) means minimal clutter in the set of
+  # methods available to the binding.
   class Renderer
     def initialize(text, safe_level = nil, trim_mode = nil)
       @template = ERB.new text, safe_level, trim_mode
@@ -13,15 +17,25 @@ module PatternPatch
     #     result = renderer.render a: 'foo', b: 1
     # @param locals_or_binding [Hash, Binding] a Hash of locals or a Binding
     # @return the result of rendering the template
+    # @raise ArgumentError for invalid locals
     def render(locals_or_binding = {})
-      if !locals_or_binding.kind_of?(Hash)
-        # Pass a Binding this way.
-        @template.result locals_or_binding
-      elsif template.respond_to? :result_with_hash
+      # Pass a Binding this way.
+      return @template.result(locals_or_binding) unless locals_or_binding.kind_of?(Hash)
+
+      @locals = locals_or_binding.symbolize_keys
+      # Any local that corresponds to a method name in this class is invalid
+      # because it cannot trigger method_missing. The same goes for
+      # locals_or_binding, the only local variable.
+      # Avoid new methods and local variables, which will be visible in the binding.
+      # Could validate only for Ruby < 2.5, but better to be consistent.
+      if @locals.any? { |l| respond_to?(l) || l == :locals_or_binding }
+        raise ArgumentError, "Invalid locals: #{@locals.select { |l| respond_to?(l) || l == :locals_or_binding }.map(&:to_str).join ', '}"
+      end
+
+      if @template.respond_to? :result_with_hash
         # ERB#result_with_hash requires Ruby 2.5.
         @template.result_with_hash locals_or_binding
       else
-        @locals = locals_or_binding.symbolize_keys
         @template.result binding
       end
     end

--- a/lib/pattern_patch/renderer.rb
+++ b/lib/pattern_patch/renderer.rb
@@ -11,22 +11,23 @@ module PatternPatch
     #     renderer = Renderer.new template_text
     #     result = renderer.render binding
     #     result = renderer.render a: 'foo', b: 1
-    # @param locals [Hash, Binding] a Binding or a Hash of locals
-    def render(locals = {})
-      if !locals.kind_of?(Hash)
-        # Pass a binding this way.
-        template.result locals
+    # @param locals_or_binding [Hash, Binding] a Hash of locals or a Binding
+    # @return the result of rendering the template
+    def render(locals_or_binding = {})
+      if !locals_or_binding.kind_of?(Hash)
+        # Pass a Binding this way.
+        template.result locals_or_binding
       elsif template.respond_to? :result_with_hash
         # ERB#result_with_hash requires Ruby 2.5.
-        template.result_with_hash locals
+        template.result_with_hash locals_or_binding
       else
-        @locals = locals
+        @locals = locals_or_binding
         template.result binding
       end
     end
 
     def method_missing(method_sym, *args, &block)
-      return super unless @locals.has_key?(method_sym)
+      return super unless @locals.key?(method_sym)
 
       @locals[method_sym]
     end

--- a/lib/pattern_patch/version.rb
+++ b/lib/pattern_patch/version.rb
@@ -1,3 +1,3 @@
 module PatternPatch
-  VERSION = "1.0.1"
+  VERSION = "1.1.0"
 end


### PR DESCRIPTION
Support passing a Hash of local variables to Patch#apply and #revert.

```Ruby
PatternPatch::Patch.new(
  regexp: /x/,
  text: '<%= replacement_text %>',
  mode: :replace
).apply file_path, locals: { replacement_text: 'y' }
```

Locals are incompatible with a binding option. This will raise an ArgumentError:

```Ruby
PatternPatch::Patch.new(
  regexp: /x/,
  text: '<%= replacement_text %>',
  mode: :replace
).apply file_path, locals: { replacement_text: 'y' }, binding: binding
```

Tests to come. ~~The API may change slightly as well.~~ There is now a `:locals` option to
Patch#apply and #revert. This avoids the possibility of locals conflicting with other options. And looks suspiciously like actionpack. 🤔